### PR TITLE
feat(Crawler): Allow for JSON content

### DIFF
--- a/src/crawler/index.js
+++ b/src/crawler/index.js
@@ -55,7 +55,7 @@ function getFolders(source) {
 		const id = file.substr(file.lastIndexOf(sep) + 1);
 		const format = getExtensionFromFilename(id);
 		return {
-			id: file.substr(file.lastIndexOf(sep) + 1),
+			id: id,
 			path: file,
 			details: getDetails(format, data),
 			preview: getPreview(data)

--- a/src/crawler/index.js
+++ b/src/crawler/index.js
@@ -1,15 +1,40 @@
 const fs = require('fs');
 const { join, sep } = require('path');
 
-function getDetails(data) {
-	const matadata = data.match(/---(.*(\r)?\n)*---/g)[0];
-	const details =  matadata.match(/(.*):(.*)/g).reduce((obj, detail) => {
+function parseMarkdownToObject(markdownString) {
+	const markDown = markdownString.match(/---(.*(\r)?\n)*---/g);
+	const metadata = markDown[0];
+
+	const details = metadata.match(/(.*):(.*)/g).reduce((obj, detail) => {
 		const value = detail.substr(detail.indexOf(':') + 2);
 		const key = detail.substr(0, detail.indexOf(':'));
 		obj[key] = value;
 		return obj;
 	}, {});
+
 	return details;
+}
+
+function getExtensionFromFilename(fileName) {
+	return fileName.substr(fileName.lastIndexOf('.') + 1);
+}
+
+function getDetails(format, data) {
+	const formatNormalised = format.toLowerCase();
+
+	switch (formatNormalised) {
+		case 'md': {
+			return parseMarkdownToObject(data);
+		}
+
+		case 'json': {
+			return JSON.parse(data);
+		}
+
+		default: {
+			console.error('File format not recognised');
+		}
+	}
 }
 
 function getPreview(data) {
@@ -26,11 +51,12 @@ function getFolders(source) {
 	let allContent = getAllListings(source);
 	const edges = allContent.filter(isFile).map(file => {
 		const data = fs.readFileSync(file, 'utf-8');
-		// console.log('get folders', JSON.stringify(data))
+		const id = file.substr(file.lastIndexOf(sep) + 1);
+		const format = getExtensionFromFilename(id);
 		return {
 			id: file.substr(file.lastIndexOf(sep) + 1),
 			path: file,
-			details: getDetails(data),
+			details: getDetails(format, data),
 			preview: getPreview(data)
 		};
 	});

--- a/src/crawler/index.js
+++ b/src/crawler/index.js
@@ -23,7 +23,8 @@ function getDetails(format, data) {
 	const formatNormalised = format.toLowerCase();
 
 	switch (formatNormalised) {
-		case 'md': {
+		case 'md':
+		case 'markdown': {
 			return parseMarkdownToObject(data);
 		}
 


### PR DESCRIPTION
This PR successfully passes `json` content (generated by netlify into the `./content` dir) to the prerender-data.