### PR TITLE
add --prerender flag to dev script

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "start:production": "npm run -s serve",
     "start:development": "npm run -s dev",
     "build": "preact build --prerenderUrls ./prerender-urls.js",
-    "dev": "preact watch --prerenderUrls ./prerender-urls.js",
+    "dev": "preact watch --prerender --prerenderUrls ./prerender-urls.js",
     "lint": "eslint src",
     "test": "jest"
   },


### PR DESCRIPTION
currently, `yarn dev` does not generate the content before it starts the web server so you end up unable to get the static content locally and see this error in your console:
```
GET http://0.0.0.0:8080/preact_prerender_data.json 404 (Not Found)
```